### PR TITLE
feat: add release workflow and prompt for production deployments

### DIFF
--- a/.github/prompts/release.latest.prompt.md
+++ b/.github/prompts/release.latest.prompt.md
@@ -1,0 +1,77 @@
+# Release Latest Changes to Production
+
+## Overview
+
+This prompt guides the release of changes from `main` to the `release` branch for Cloudflare Pages deployment.
+
+## Prerequisites
+
+- All CI checks passing on `main`
+- You have admin access to the repository
+- GitHub CLI (`gh`) is authenticated
+
+## Release Process
+
+### Option 1: GitHub Actions Workflow (Recommended)
+
+1. Go to **Actions** → **Release to Production**
+2. Click **Run workflow**
+3. Type `release` in the confirmation field
+4. Click **Run workflow**
+
+The workflow will:
+- Unlock the `release` branch
+- Fast-forward merge from `main`
+- Create a tag in format `yy.mdd.rev`
+- Re-lock the `release` branch
+
+### Option 2: Manual Release (PowerShell)
+
+```powershell
+# 1. Unlock release branch
+gh api repos/{owner}/{repo}/branches/release/protection -X DELETE
+
+# 2. Fast-forward merge
+git fetch origin
+git checkout release
+git merge --ff-only origin/main
+git push origin release
+
+# 3. Create tag (format: yy.mdd.rev)
+$year = Get-Date -Format "yy"
+$monthDay = (Get-Date).Month.ToString() + (Get-Date -Format "dd")
+$datePrefix = "$year.$monthDay"
+
+# Find next revision number
+$existingTags = git tag -l "$datePrefix.*" | Sort-Object -Property { [version]$_ } | Select-Object -Last 1
+if ($existingTags) {
+    $lastRev = [int]($existingTags -replace "$datePrefix\.", "")
+    $rev = $lastRev + 1
+} else {
+    $rev = 0
+}
+
+$newTag = "$datePrefix.$rev"
+git tag $newTag
+git push origin $newTag
+
+# 4. Re-lock release branch
+gh api repos/{owner}/{repo}/branches/release/protection -X PUT -f lock_branch=true -f enforce_admins=true -f allow_force_pushes=false -f allow_deletions=false
+```
+
+## Tag Format
+
+Tags follow the format `{yy}.{mdd}.{rev}`:
+- `yy` - Two-digit year
+- `m` - Month (1-12, no leading zero)
+- `dd` - Day (01-31)
+- `rev` - Revision number starting at 0
+
+Examples:
+- `26.114.0` - January 14, 2026, first release
+- `26.114.1` - January 14, 2026, second release
+- `26.1231.0` - December 31, 2026, first release
+
+## Cloudflare Pages
+
+The `release` branch is connected to Cloudflare Pages for production deployment. After the release workflow completes, Cloudflare will automatically build and deploy the changes.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+name: Release to Production
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "release" to confirm'
+        required: true
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.event.inputs.confirm == 'release'
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Unlock release branch
+        run: |
+          gh api repos/${{ github.repository }}/branches/release/protection \
+            -X DELETE || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fast-forward release to main
+        run: |
+          git checkout release
+          git merge --ff-only origin/main
+          git push origin release
+
+      - name: Create release tag
+        run: |
+          # Format: yy.mdd.rev (e.g., 26.114.0 = Jan 14, 2026, first release of day)
+          YEAR=$(date +%y)
+          MONTH=$(date +%-m)
+          DAY=$(date +%d)
+          DATE_PREFIX="${YEAR}.${MONTH}${DAY}"
+          
+          # Find existing tags for today and determine revision
+          EXISTING_TAGS=$(git tag -l "${DATE_PREFIX}.*" | sort -V | tail -1)
+          if [ -z "$EXISTING_TAGS" ]; then
+            REV=0
+          else
+            LAST_REV=$(echo "$EXISTING_TAGS" | sed "s/${DATE_PREFIX}\.//")
+            REV=$((LAST_REV + 1))
+          fi
+          
+          NEW_TAG="${DATE_PREFIX}.${REV}"
+          echo "Creating tag: $NEW_TAG"
+          
+          git tag "$NEW_TAG"
+          git push origin "$NEW_TAG"
+          
+          echo "TAG_NAME=$NEW_TAG" >> $GITHUB_ENV
+
+      - name: Lock release branch
+        run: |
+          gh api repos/${{ github.repository }}/branches/release/protection \
+            -X PUT \
+            -H "Accept: application/vnd.github+json" \
+            -f lock_branch=true \
+            -f required_status_checks=null \
+            -f enforce_admins=true \
+            -f required_pull_request_reviews=null \
+            -f restrictions=null \
+            -f allow_force_pushes=false \
+            -f allow_deletions=false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Summary
+        run: |
+          echo "## Release Complete! 🚀" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Tag:** \`${{ env.TAG_NAME }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The \`release\` branch has been fast-forwarded to \`main\` and locked." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Adds automated release workflow and documentation for deploying changes from `main` to the `release` branch.

## Changes

- **`.github/workflows/release.yml`** - GitHub Actions workflow that:
  - Unlocks the `release` branch
  - Fast-forward merges from `main`
  - Creates a tag in `yy.mdd.rev` format
  - Re-locks the `release` branch

- **`.github/prompts/release.latest.prompt.md`** - Documentation with:
  - Instructions for using the automated workflow
  - Manual PowerShell commands as backup
  - Tag format explanation

## Release Process

1. Make changes via PRs to `main` (squash merge)
2. Run the **Release to Production** workflow
3. Cloudflare Pages auto-deploys from `release` branch

## Tag Format

`{yy}.{mdd}.{rev}` - e.g., `26.114.0` = January 14, 2026, first release