### PR TITLE
fix: add missing tools to github.pr prompt

### DIFF
--- a/.github/prompts/github.pr.prompt.md
+++ b/.github/prompts/github.pr.prompt.md
@@ -1,6 +1,7 @@
 ---
 description: 'Action-driven PR workflow: create, monitor CI, fix failures, address reviews, push changes'
 tools:
+  # GitHub PR operations
   - github
   - create_pull_request
   - update_pull_request
@@ -14,10 +15,18 @@ tools:
   - merge_pull_request
   - get_me
   - githubRepo
+  # Terminal for running commands (git, npm, gh)
   - runCommands/runInTerminal
   - runCommands/getTerminalOutput
+  # File operations (needed for CI fixes and review comments)
   - editFiles/editFile
+  - editFiles/createFile
+  - changes/getChangedFiles
   - codebase
+  - codebase/search
+  - findFiles/file_search
+  - findFiles/grep_search
+  - problems/getErrors
 ---
 
 # GitHub Pull Request Workflow


### PR DESCRIPTION
## Summary

Adds missing tools to the github.pr prompt that are needed for CI fixes and addressing review comments.

## Added Tools

| Tool | Purpose |
|------|---------|
| `editFiles/createFile` | Create new files |
| `changes/getChangedFiles` | View git diff |
| `codebase/search` | Semantic search |
| `findFiles/file_search` | Find files by pattern |
| `findFiles/grep_search` | Search file contents |
| `problems/getErrors` | Get lint/type errors |

## Why

The "Fix CI Failures" and "Address Review Comments" workflows require reading files and finding errors, which wasn't possible with the restricted tools list.