### PR TITLE
docs(ci): address Copilot review comments for documentation polish

### DIFF
--- a/.github/workflows/CI_IMPROVEMENTS.md
+++ b/.github/workflows/CI_IMPROVEMENTS.md
@@ -66,9 +66,10 @@ setup
 
 ### 6. Separated Build Job
 - Build now runs as a separate job with artifact upload
-- E2E tests download the build artifacts instead of rebuilding
-- **Benefit**: Build once, test in multiple configurations (future: multiple browsers)
-- **Impact**: Eliminates redundant builds in E2E tests
+- Build artifacts are uploaded for inspection and potential future use
+- **Note**: E2E tests currently run against the dev server (`npm run dev`), not the production build
+- **Benefit**: Validates the production build succeeds; enables future reuse across multiple browser configurations
+- **Impact**: Ensures build issues are caught early while keeping E2E tests fast
 
 ### 7. Enhanced Artifact Handling
 

--- a/.github/workflows/CI_QUICK_REFERENCE.md
+++ b/.github/workflows/CI_QUICK_REFERENCE.md
@@ -158,7 +158,7 @@ git commit -m "docs: update README [skip ci]"
 
 ## Node.js Version
 
-The CI uses Node.js v22 (required by Waku dependencies).
+The CI uses Node.js v22 (minimum version required by Waku dependencies; >= 22 supported).
 
 To match locally:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # CI Workflow for gametime-bingo
 #
 # Improvements over previous version:
-# - Updated Node.js to v22 (required by Waku dependencies)
+# - Updated Node.js to v22 (minimum version required by Waku dependencies)
 # - Added concurrency control to cancel redundant runs
 # - Optimized caching strategy (node_modules + Playwright browsers)
 # - Added job dependencies for better parallelization
@@ -24,7 +24,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Single job for installing dependencies to share with downstream jobs
+  # Single job for installing dependencies and populating cache for downstream jobs
   setup:
     name: Setup & Install Dependencies
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Addresses the 5 documentation polish comments from the Copilot review on PR #91 that were not fixed before merging.

## Changes

### ci.yml
1. **Line 4**: Changed "required by Waku dependencies" → "minimum version required by Waku dependencies"
2. **Line 27**: Changed "to share with downstream jobs" → "and populating cache for downstream jobs"

### CI_IMPROVEMENTS.md
3. **Line 71**: Clarified that build artifacts are uploaded for inspection but E2E tests run against dev server (`npm run dev`), not production build

### CI_QUICK_REFERENCE.md
4. **Line 161**: Added clarification that Node.js >= 22 is supported, not just exactly v22

## Review Comments Addressed

From [PR #91 Copilot review](https://github.com/amitjoshi-ms/gametime-bingo/pull/91#pullrequestreview-3663830695):
- ✅ Node.js version comment accuracy
- ✅ Setup job comment clarification
- ✅ Build artifact usage documentation
- ✅ Node.js version in quick reference

## Testing

- All local checks pass (lint, type check, unit tests, E2E tests)