### PR TITLE
fix: update copilot-instructions.md to use npm instead of pnpm

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,7 +23,7 @@ tests/
 
 ## Commands
 
-pnpm dev; pnpm test; pnpm lint
+npm run dev; npm run test; npm run lint
 
 ## Code Style
 


### PR DESCRIPTION
## Problem

The `.github/copilot-instructions.md` file references `pnpm` commands:

```
pnpm dev; pnpm test; pnpm lint
```

However, the project actually uses **npm** as evidenced by:
- `package-lock.json` exists (not `pnpm-lock.yaml`)
- CI workflow (`.github/workflows/ci.yml`) uses `npm ci`, `npm run lint`, `npm run test`, etc.

## Impact

This inconsistency causes Copilot to suggest incorrect commands and generates false positive review comments.

## Solution

Updated `.github/copilot-instructions.md` to use npm commands:

```
npm run dev; npm run test; npm run lint
```

- Fixes #79